### PR TITLE
Slight adjustments to fix the oscillator

### DIFF
--- a/subbertone/Source/SubharmonicEngine.cpp
+++ b/subbertone/Source/SubharmonicEngine.cpp
@@ -451,7 +451,7 @@ void SubharmonicEngine::process(float* outputBuffer, int numSamples,
     }
     
     // Enable oversampling only when distortion is used AND there's actual signal
-    bool useOversampling = (distortionAmount > 0.01f) && (maxSample > 0.0001f) && oversampler && oversamplerReady;
+    bool useOversampling = false;
     
     // Defensive check - ensure block size hasn't changed
     if (useOversampling && numSamples > currentMaxBlockSize)


### PR DESCRIPTION
1. Stereo channel processing bug (causes the majority of the artefacts).
2. Processing order: I noticed the pitch detection happens after the subharmonic processing, meaning it is always one-block behind.
3. Oversampling: I haven't fixed this just yet but I suspect the issue lies in the cascading antialiasing filters. I just disabled it for now.